### PR TITLE
bugfix to listCarousel saving functionality

### DIFF
--- a/src/components/carousel/ImageCarousel.js
+++ b/src/components/carousel/ImageCarousel.js
@@ -26,12 +26,6 @@ export default function ImageCarousel({type,updateItem}){
         updateItem(type,image_id);
     }
 
-    useEffect(()=>{
-        if(data && data.length === 0){ // if there is no data in the category update the attibute to be false
-            updateItem(type,false);
-        }  
-    },[data])
-
     return (
         <>
             <h2 className={`title is-2 ${styles.heading}`}>{type}</h2>
@@ -50,7 +44,7 @@ export default function ImageCarousel({type,updateItem}){
                             })
                         }
                     </Carousel>
-                    { (data && data.length === 0) && <p className={styles.label}>No images in this category</p>}               
+                    { (data && data.length === 0) && <p id={`noData-${type}`} className={styles.label}>No images in this category</p>}               
                 </div>
             </div>
         </>

--- a/src/components/carousel/ListCarousel.js
+++ b/src/components/carousel/ListCarousel.js
@@ -23,8 +23,21 @@ export default function ListCarousel({ typeList, token }) {
 	async function saveOutfit(e) {
 		e.preventDefault();
 		setLoading(true);
-		// first remove outfits from type list that don't have data i.e. indices[type] === false
-		const newTypeList = typeList.filter((type) => indices[type] !== false);
+		// first remove outfits from type list that don't have data 
+        const newTypeList = typeList.filter((type) => {
+            if(indices[type] == undefined){
+                const checkNoData = document.getElementById(`noData-${type}`); // if we are displaying "No images in this category"
+                if(checkNoData){
+                    return false;
+                }
+                else{
+                    return true;
+                }
+            }
+            else{
+                return true;
+            }
+        });
 		// Lets build a POST request
 		let items = [];
 		let typeOrder = [];


### PR DESCRIPTION
Previously we were setting values to save which had no data to `false` however setting these values while rendering caused inconsistent results. Therefore now we rely on checking the id of the element which displays "No images in this category" .